### PR TITLE
WebTorrent compatibility improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,8 +97,8 @@ IdbChunkStore.prototype.get = function (index, opts, cb) {
       e.name = 'MissingChunkError'
       return cb(e)
     }
-    var offset = 'offset' in opts ? opts.offset : 0
-    var length = 'length' in opts ? opts.length : buffer.length - offset
+    var offset = opts.offset != undefined ? opts.offset : 0
+    var length = opts.length != undefined ? opts.length : buffer.length - offset
     cb(null, (Buffer.from(buffer)).slice(offset, offset + length))
   })
 }

--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ function IdbChunkStore (chunkLength, opts, cb) {
   }
 
   var name = opts.name || '' + Math.round(9e16 * Math.random())
-  // for webtorrent
-  if (opts.torrent && opts.torrent.infoHash) name = opts.torrent.infoHash
 
   self._store = new IdbKvStore(name, cb)
   self._store.on('close', onClose)


### PR DESCRIPTION
1. Remove obsolete WebTorrent name detection. WebTorrent has passed `opts.name` since v0.102.3 in August 2018
2. Don't fail in `store.get` when `opts.offset == undefined` or `opts.length == undefined`. We worked around this on the WebTorrent side as of https://github.com/webtorrent/webtorrent/commit/4cbce24f24005ddab216ce94da7716400baafff9 but the change here improves robustness in general.